### PR TITLE
Do not send exception details in the HTTP reply

### DIFF
--- a/src/main/python/aws_federation_proxy/wsgi_api/wsgi_api.py
+++ b/src/main/python/aws_federation_proxy/wsgi_api/wsgi_api.py
@@ -4,7 +4,6 @@ from __future__ import print_function, absolute_import, division
 
 import datetime
 import logging
-import traceback
 import simplejson
 
 from aws_federation_proxy import (
@@ -29,18 +28,18 @@ def with_exception_handling(old_function):
         logger = logging.getLogger(LOGGER_NAME)
         try:
             result = old_function(*args, **kwargs)
-        except ConfigurationError as err:
+        except ConfigurationError:
             logger.exception("Call to '%s' failed:", old_function.__name__)
-            abort(404, err)
-        except AWSError as err:
+            abort(404, "ConfigurationError")
+        except AWSError:
             logger.exception("AWS call in '%s' failed:", old_function.__name__)
-            abort(502, err)
-        except PermissionError as err:
-            abort(403, err)
+            abort(502, "Call to AWS failed")
+        except PermissionError:
+            logger.exception("Permission denied:")
+            abort(403, "Permission Denied")
         except Exception:
             logger.exception("Call to '%s' failed:", old_function.__name__)
-            message = traceback.format_exc()
-            abort(500, "Exception caught {0}".format(message))
+            abort(500, "Internal Server Error")
         return result
     return new_function
 

--- a/src/unittest/python/api_endpoint_tests.py
+++ b/src/unittest/python/api_endpoint_tests.py
@@ -351,17 +351,17 @@ class AFPEndpointTest(BaseEndpointTest):
         self.assertEqual(result.status_int, 403)
         self.assertEqual(self.user, result.headers['X-Username'])
 
-        result.mustcontain("may not access")
+        result.mustcontain("Permission Denied")
         result = self.app.get('/account/testaccount/illegalrole/credentials',
                               expect_errors=True)
         self.assertEqual(result.status_int, 403)
-        result.mustcontain("may not access")
+        result.mustcontain("Permission Denied")
         self.assertEqual(self.user, result.headers['X-Username'])
 
         result = self.app.get('/account/testaccount/illegalrole/consoleurl',
                               expect_errors=True)
         self.assertEqual(result.status_int, 403)
-        result.mustcontain("may not access")
+        result.mustcontain("Permission Denied")
         self.assertEqual(self.user, result.headers['X-Username'])
 
         logged_data = str(self.log_file.read())
@@ -380,19 +380,19 @@ class AFPEndpointTest(BaseEndpointTest):
         result = self.app.get('/account/testaccount1/testrole',
                               expect_errors=True)
         self.assertEqual(result.status_int, 403)
-        result.mustcontain("may not access")
+        result.mustcontain("Permission Denied")
         self.assertEqual(self.user, result.headers['X-Username'])
 
         result = self.app.get('/account/testaccount1/testrole/credentials',
                               expect_errors=True)
         self.assertEqual(result.status_int, 403)
-        result.mustcontain("may not access")
+        result.mustcontain("Permission Denied")
         self.assertEqual(self.user, result.headers['X-Username'])
 
         result = self.app.get('/account/testaccount1/testrole/consoleurl',
                               expect_errors=True)
         self.assertEqual(result.status_int, 403)
-        result.mustcontain("may not access")
+        result.mustcontain("Permission Denied")
         self.assertEqual(self.user, result.headers['X-Username'])
 
         logged_data = str(self.log_file.read())
@@ -409,7 +409,7 @@ class AFPEndpointTest(BaseEndpointTest):
             result = self.app.get('/account/testaccount/testrole',
                                   expect_errors=True)
         self.assertEqual(result.status_int, 502)
-        result.mustcontain("aws is down")
+        result.mustcontain("Call to AWS failed")
         self.assertEqual(self.user, result.headers['X-Username'])
 
     @patch("aws_federation_proxy.aws_federation_proxy.AWSFederationProxy.get_aws_credentials")


### PR DESCRIPTION
Full exception details are still written to the log file. 
