### PR TITLE
Add account id to wsgi_api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
   - "3.6"
 
 install:
+  - pip install -U pip setuptools
   - pip install pybuilder
   - pip install coveralls
   - pyb install_dependencies

--- a/src/main/python/aws_federation_proxy/provider/ldap_provider.py
+++ b/src/main/python/aws_federation_proxy/provider/ldap_provider.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function, absolute_import, division
 
 import ldap
-
 from aws_federation_proxy.provider import ProviderByGroups
 
 
@@ -45,10 +45,10 @@ class Provider(ProviderByGroups):
 
             self.logger.debug('Groups: "%s"', results)
             return results
-        except ldap.LDAPError, e:
-            print e.message['info']
+        except ldap.LDAPError as e:
+            print(e.message['info'])
             if type(e.message) == dict and 'desc' in e.message:
-                print e.message['desc']
+                print(e.message['desc'])
             else:
-                print e
+                print(e)
         return False

--- a/src/main/python/aws_federation_proxy/wsgi_api/wsgi_api.py
+++ b/src/main/python/aws_federation_proxy/wsgi_api/wsgi_api.py
@@ -153,7 +153,8 @@ def get_accountlist(proxy):
     )
     if 'withid' in request.query:
         # "testaccount": {"id": "123456789012", "roles": ["testrole"]}
-        return dict([(x, {'id': proxy.account_config[x]['id'], 'roles': y}) for x, y in accounts_and_roles.items()])
+        return dict([(x, {'id': proxy.account_config.get(x, {}).get('id', None), 'roles': y})
+                     for x, y in accounts_and_roles.items()])
     else:
         # "testaccount": ["testrole"]
         return accounts_and_roles

--- a/src/main/python/aws_federation_proxy/wsgi_api/wsgi_api.py
+++ b/src/main/python/aws_federation_proxy/wsgi_api/wsgi_api.py
@@ -151,7 +151,12 @@ def get_accountlist(proxy):
         (key, role_set_to_list(value)) for (key, value)
         in accounts_and_roles_with_sets.items()
     )
-    return accounts_and_roles
+    if 'withid' in request.query:
+        # "testaccount": {"id": "123456789012", "roles": ["testrole"]}
+        return dict([(x, {'id': proxy.account_config[x]['id'], 'roles': y}) for x, y in accounts_and_roles.items()])
+    else:
+        # "testaccount": ["testrole"]
+        return accounts_and_roles
 
 
 @route('/account/<account>/<role>')

--- a/src/unittest/python/api_endpoint_tests.py
+++ b/src/unittest/python/api_endpoint_tests.py
@@ -244,15 +244,15 @@ class AFPEndpointTest(BaseEndpointTest):
         self.assertTrue(result.json == accounts_and_roles)
         self.assertEqual(self.user, result.headers['X-Username'])
 
-#    def test_get_list_roles_and_accounts_withid(self):
-#        result = self.app.get('/account?withid')
-#        accounts_and_roles_withid = {
-#            "testaccount": {"id": "123456789012", "roles": ["testrole"]},
-#            "testaccount1": {"id": "987654321987", "roles": ["testrole2"]}
-#        }
-#        self.assertEqual(result.status_int, 200)
-#        self.assertTrue(result.json == accounts_and_roles_withid)
-#        self.assertEqual(self.user, result.headers['X-Username'])
+    def test_get_list_roles_and_accounts_withid(self):
+        result = self.app.get('/account?withid')
+        accounts_and_roles_withid = {
+            u"testaccount": {u"id": u"123456789", u"roles": [u"testrole"]},
+            u"testaccount1": {u"id": None, u"roles": [u"testrole2"]}
+        }
+        self.assertEqual(result.status_int, 200)
+        self.assertEqual(result.json, accounts_and_roles_withid)
+        self.assertEqual(self.user, result.headers['X-Username'])
 
     @mock_sts
     def test_get_credentials(self):

--- a/src/unittest/python/api_endpoint_tests.py
+++ b/src/unittest/python/api_endpoint_tests.py
@@ -244,6 +244,16 @@ class AFPEndpointTest(BaseEndpointTest):
         self.assertTrue(result.json == accounts_and_roles)
         self.assertEqual(self.user, result.headers['X-Username'])
 
+#    def test_get_list_roles_and_accounts_withid(self):
+#        result = self.app.get('/account?withid')
+#        accounts_and_roles_withid = {
+#            "testaccount": {"id": "123456789012", "roles": ["testrole"]},
+#            "testaccount1": {"id": "987654321987", "roles": ["testrole2"]}
+#        }
+#        self.assertEqual(result.status_int, 200)
+#        self.assertTrue(result.json == accounts_and_roles_withid)
+#        self.assertEqual(self.user, result.headers['X-Username'])
+
     @mock_sts
     def test_get_credentials(self):
         result = self.app.get('/account/testaccount/testrole/credentials')


### PR DESCRIPTION
extension of the wsgi_api so that the account_id is displayed and can be used e.g. in afp-web

example:
".../afp-api/latest/account?withid"
 returns
'"testaccount": {"id": "123456789012", "roles": ["testrole"]}'

